### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,8 @@
 name: build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ["master", "dev"]


### PR DESCRIPTION
Potential fix for [https://github.com/miguerubsk/MinecraftCrawler/security/code-scanning/1](https://github.com/miguerubsk/MinecraftCrawler/security/code-scanning/1)

In general, the fix is to explicitly define the minimal required `permissions` for the GITHUB_TOKEN in the workflow or job. Since this workflow only checks out code and builds/tests it, it only needs read access to repository contents. The least-privilege configuration is therefore `permissions: contents: read`.

The single best way to fix this without changing existing functionality is to add a `permissions` block at the workflow root (top level, next to `name` and `on`), so it applies to all jobs. Concretely, in `.github/workflows/go.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `name: build` line and the `on:` block. No other changes, imports, or additional definitions are needed, and this will satisfy the CodeQL rule while keeping the workflow behavior identical.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
