### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -11,6 +11,9 @@ jobs:
   labels:
     name: ♻️ Sync labels
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: ⤵️ Check out code from GitHub
         uses: actions/checkout@v2


### PR DESCRIPTION
Potential fix for [https://github.com/miguerubsk/MinecraftCrawler/security/code-scanning/2](https://github.com/miguerubsk/MinecraftCrawler/security/code-scanning/2)

In general, the problem is solved by adding an explicit `permissions` block that grants only the minimal scopes the job needs. This can be added at the workflow root (applies to all jobs) or at the job level (applies only to that job). Here, adding it at the job level keeps the change narrowly targeted.

The `micnncim/action-label-syncer` action updates labels in the repository via the GitHub API using `GITHUB_TOKEN`. That requires permission to read repository metadata and write to issues/labels, but it does not need broad write access to repository contents. A minimal, safe configuration is to grant `contents: read` (for general repo visibility/metadata) and `issues: write` (for label management). We will therefore add:

```yaml
permissions:
  contents: read
  issues: write
```

under the `labels` job, aligned with its indentation. No imports or other definitions are needed; only the YAML in `.github/workflows/labels.yml` is updated. Concretely, we’ll insert the `permissions` block between `runs-on: ubuntu-latest` (line 13) and `steps:` (line 14).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
