### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   pr_labels:
     name: 🏭 Verify
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: 🏷 Verify PR has a valid label


### PR DESCRIPTION
Potential fix for [https://github.com/miguerubsk/MinecraftCrawler/security/code-scanning/3](https://github.com/miguerubsk/MinecraftCrawler/security/code-scanning/3)

In general, the fix is to explicitly declare a `permissions` block for the workflow/job so that the `GITHUB_TOKEN` has only the minimal scopes required. This avoids inheriting possibly over-privileged defaults and documents the intended access.

For this specific workflow, the `pr_labels` job is only verifying that PRs have a valid label; the action primarily needs to read PR data. It does not need broad write access to repository contents. A safe, minimal configuration is to set `contents: read` at the job level. If the action must update PR reviews or labels, more granular permissions like `pull-requests: write` could be added, but since the configuration sets `disable-reviews: true` and does not indicate any write activity, we can keep it read-only.

Concretely, in `.github/workflows/pr-labels.yml`, under `jobs: pr_labels:`, add a `permissions:` section before `runs-on:`:

- Insert:
  ```yaml
    permissions:
      contents: read
  ```
- Keep the rest of the job unchanged.
No additional imports or definitions are required; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
