### PR TITLE
feat: initial 'info' command and SRV resolution #21

### DIFF
--- a/cmd/info.go
+++ b/cmd/info.go
@@ -19,7 +19,7 @@ and attempts UDP Query protocol extraction.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		target := args[0]
 
-		fmt.Printf("🔍 Analyzing target: %s\n", target)
+		fmt.Printf("Analyzing target: %s\n", target)
 
 		// 1. TODO: Implement SRV Resolution (Issue #21)
 		host := target

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+
 	"github.com/spf13/cobra"
 	// "github.com/fatih/color" <-- Para el Hito 03
 )
@@ -17,7 +18,7 @@ and attempts UDP Query protocol extraction.`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		target := args[0]
-		
+
 		fmt.Printf("🔍 Analyzing target: %s\n", target)
 
 		// 1. TODO: Implement SRV Resolution (Issue #21)
@@ -30,8 +31,12 @@ and attempts UDP Query protocol extraction.`,
 				return fmt.Errorf("invalid port in target: %v", err)
 			}
 		} else {
-			// Si no hay puerto, comprobamos si es una IP literal (v4 o v6)
-			// Si es IP, no intentamos SRV lookup
+			// Si falla SplitHostPort, comprobamos si es por un IPv6 mal formateado (sin corchetes pero con puerto)
+			if strings.Count(target, ":") > 1 && !strings.Contains(target, "[") {
+				return fmt.Errorf("malformed IPv6 address: use '[addr]:port' format for IPv6 with literal ports")
+			}
+
+			// Comprobamos si es una IP literal (v4 o v6)
 			if net.ParseIP(target) != nil {
 				fmt.Printf("[*] IP address detected, skipping SRV lookup for %s\n", host)
 			} else {
@@ -42,6 +47,13 @@ and attempts UDP Query protocol extraction.`,
 					host = strings.TrimSuffix(addrs[0].Target, ".")
 					port = int(addrs[0].Port)
 					fmt.Printf("SRV found: %s:%d\n", host, port)
+				} else if err != nil {
+					// Diferenciamos errores de DNS
+					if dnsErr, ok := err.(*net.DNSError); ok && dnsErr.IsNotFound {
+						fmt.Println("No SRV record found, using default port 25565")
+					} else {
+						return fmt.Errorf("DNS resolution error: %v", err)
+					}
 				} else {
 					fmt.Println("No SRV record found, using default port 25565")
 				}
@@ -54,7 +66,7 @@ and attempts UDP Query protocol extraction.`,
 
 		// 2. TODO: Trigger AnalyzeServer logic (Issue #22)
 		// 3. TODO: Format rich output (Issue #23)
-		
+
 		fmt.Printf("[*] Target resolved: %s:%d\n", host, port)
 		fmt.Println("Logic for deep analysis (Issue #22) and rich UI (Issue #23) pending.")
 		return nil

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 	"net"
-	"os"
+	"strings"
 	"github.com/spf13/cobra"
 	// "github.com/fatih/color" <-- Para el Hito 03
 )

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"github.com/spf13/cobra"
 	// "github.com/fatih/color" <-- Para el Hito 03
@@ -20,6 +21,25 @@ and attempts UDP Query protocol extraction.`,
 		fmt.Printf("🔍 Analyzing target: %s\n", target)
 
 		// 1. TODO: Implement SRV Resolution (Issue #1)
+		host := target
+		port := 25565
+
+		if h, p, err := net.SplitHostPort(target); err == nil {
+			host = h
+			fmt.Sscanf(p, "%d", &port)
+		} else {
+			// Intento de resolución SRV si no hay puerto explícito
+			fmt.Printf("[*] No port specified, attempting SRV lookup for %s...\n", host)
+			_, addrs, err := net.LookupSRV("minecraft", "tcp", host)
+			if err == nil && len(addrs) > 0 {
+				host = strings.TrimSuffix(addrs[0].Target, ".")
+				port = int(addrs[0].Port)
+				fmt.Printf("✅ SRV found: %s:%d\n", host, port)
+			} else {
+				fmt.Println("ℹ️ No SRV record found, using default port 25565")
+			}
+		}
+
 		// 2. TODO: Trigger AnalyzeServer logic (Issue #2)
 		// 3. TODO: Format rich output (Issue #3)
 		

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -24,9 +24,10 @@ and attempts UDP Query protocol extraction.`,
 		host := target
 		port := 25565
 
-		if h, p, err := net.SplitHostPort(target); err == nil {
-			host = h
-			fmt.Sscanf(p, "%d", &port)
+		if _, p, err := net.SplitHostPort(target); err == nil {
+			if _, err := fmt.Sscanf(p, "%d", &port); err != nil {
+				fmt.Printf("Invalid port in target: %v\n", err)
+			}
 		} else {
 			// Intento de resolución SRV si no hay puerto explícito
 			fmt.Printf("[*] No port specified, attempting SRV lookup for %s...\n", host)

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	// "github.com/fatih/color" <-- Para el Hito 03
+	// TODO: Integrate colored console output (milestone 03) using github.com/fatih/color
 )
 
-var infoCmd = &cobra.Command{
+var InfoCmd = &cobra.Command{
 	Use:   "info [target]",
 	Short: "Deep analysis of a single Minecraft server",
 	Long: `Performs a comprehensive analysis of a specific server.
@@ -31,15 +31,15 @@ and attempts UDP Query protocol extraction.`,
 				return fmt.Errorf("invalid port in target: %v", err)
 			}
 		} else {
-			// Si falla SplitHostPort, comprobamos si es por un IPv6 mal formateado (sin corchetes pero con puerto)
-			if strings.Count(target, ":") > 1 && !strings.Contains(target, "[") {
-				return fmt.Errorf("malformed IPv6 address: use '[addr]:port' format for IPv6 with literal ports")
-			}
-
-			// Comprobamos si es una IP literal (v4 o v6)
+			// Comprobamos si es una IP literal (v4 o v6) antes de cualquier otra lógica
 			if net.ParseIP(target) != nil {
 				fmt.Printf("[*] IP address detected, skipping SRV lookup for %s\n", host)
 			} else {
+				// Si no es un IP válida y tiene varios ":", es un IPv6 mal formateado (le faltan los [])
+				if strings.Count(target, ":") > 1 {
+					return fmt.Errorf("malformed IPv6 address: use '[addr]:port' format for IPv6 with literal ports")
+				}
+
 				// Intento de resolución SRV si no hay puerto explícito ni es IP
 				fmt.Printf("[*] No port specified, attempting SRV lookup for %s...\n", host)
 				_, addrs, err := net.LookupSRV("minecraft", "tcp", host)
@@ -74,5 +74,5 @@ and attempts UDP Query protocol extraction.`,
 }
 
 func init() {
-	rootCmd.AddCommand(infoCmd)
+	rootCmd.AddCommand(InfoCmd)
 }

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -15,36 +15,49 @@ var infoCmd = &cobra.Command{
 It resolves SRV records, performs Server List Ping (SLP), 
 and attempts UDP Query protocol extraction.`,
 	Args: cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		target := args[0]
 		
 		fmt.Printf("🔍 Analyzing target: %s\n", target)
 
-		// 1. TODO: Implement SRV Resolution (Issue #1)
+		// 1. TODO: Implement SRV Resolution (Issue #21)
 		host := target
 		port := 25565
 
-		if _, p, err := net.SplitHostPort(target); err == nil {
+		if h, p, err := net.SplitHostPort(target); err == nil {
+			host = h
 			if _, err := fmt.Sscanf(p, "%d", &port); err != nil {
-				fmt.Printf("Invalid port in target: %v\n", err)
+				return fmt.Errorf("invalid port in target: %v", err)
 			}
 		} else {
-			// Intento de resolución SRV si no hay puerto explícito
-			fmt.Printf("[*] No port specified, attempting SRV lookup for %s...\n", host)
-			_, addrs, err := net.LookupSRV("minecraft", "tcp", host)
-			if err == nil && len(addrs) > 0 {
-				host = strings.TrimSuffix(addrs[0].Target, ".")
-				port = int(addrs[0].Port)
-				fmt.Printf("✅ SRV found: %s:%d\n", host, port)
+			// Si no hay puerto, comprobamos si es una IP literal (v4 o v6)
+			// Si es IP, no intentamos SRV lookup
+			if net.ParseIP(target) != nil {
+				fmt.Printf("[*] IP address detected, skipping SRV lookup for %s\n", host)
 			} else {
-				fmt.Println("ℹ️ No SRV record found, using default port 25565")
+				// Intento de resolución SRV si no hay puerto explícito ni es IP
+				fmt.Printf("[*] No port specified, attempting SRV lookup for %s...\n", host)
+				_, addrs, err := net.LookupSRV("minecraft", "tcp", host)
+				if err == nil && len(addrs) > 0 {
+					host = strings.TrimSuffix(addrs[0].Target, ".")
+					port = int(addrs[0].Port)
+					fmt.Printf("SRV found: %s:%d\n", host, port)
+				} else {
+					fmt.Println("No SRV record found, using default port 25565")
+				}
 			}
 		}
 
-		// 2. TODO: Trigger AnalyzeServer logic (Issue #2)
-		// 3. TODO: Format rich output (Issue #3)
+		if port < 1 || port > 65535 {
+			return fmt.Errorf("port out of range: %d", port)
+		}
+
+		// 2. TODO: Trigger AnalyzeServer logic (Issue #22)
+		// 3. TODO: Format rich output (Issue #23)
 		
-		fmt.Println("⚠️ Logic not yet implemented. Check Milestone 01.")
+		fmt.Printf("[*] Target resolved: %s:%d\n", host, port)
+		fmt.Println("Logic for deep analysis (Issue #22) and rich UI (Issue #23) pending.")
+		return nil
 	},
 }
 

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"github.com/spf13/cobra"
+	// "github.com/fatih/color" <-- Para el Hito 03
+)
+
+var infoCmd = &cobra.Command{
+	Use:   "info [target]",
+	Short: "Deep analysis of a single Minecraft server",
+	Long: `Performs a comprehensive analysis of a specific server.
+It resolves SRV records, performs Server List Ping (SLP), 
+and attempts UDP Query protocol extraction.`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		target := args[0]
+		
+		fmt.Printf("🔍 Analyzing target: %s\n", target)
+
+		// 1. TODO: Implement SRV Resolution (Issue #1)
+		// 2. TODO: Trigger AnalyzeServer logic (Issue #2)
+		// 3. TODO: Format rich output (Issue #3)
+		
+		fmt.Println("⚠️ Logic not yet implemented. Check Milestone 01.")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(infoCmd)
+}


### PR DESCRIPTION
## Pull Request type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The application only supported bulk scanning via the `scan` command. There was no way to analyze a single specific server or resolve Minecraft SRV records for domain-based targets.

Issue Number: #21

## What is the new behavior?

- **New Subcommand**: Added the `info [target]` command (WIP).
- **SRV Resolution**: Implemented automatic DNS SRV lookup for `_minecraft._tcp.[host]` when no port is specified.
- **Target Parsing**: Added logic to handle both plain domains/IPs and explicit `host:port` formats.
- **Traceability**: Maintained internal TODOs to guide the upcoming implementation of deep analysis (Issue #22) and rich UI formatting (Issue #23).

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This PR completes the first part of Milestone 01 (Closes #21).
